### PR TITLE
fix: 44k -> 48k

### DIFF
--- a/AudioMirror/MicrophoneWaveProperties.h
+++ b/AudioMirror/MicrophoneWaveProperties.h
@@ -9,11 +9,14 @@
 //
 // Mic in (external: headphone) range.
 //
+
+#define JJOC_MIC_SAMPLE_RATE				48000
+
 #define MICIN_DEVICE_MAX_CHANNELS           2       // Max Channels.
 #define MICIN_MIN_BITS_PER_SAMPLE_PCM       16      // Min Bits Per Sample
 #define MICIN_MAX_BITS_PER_SAMPLE_PCM       16      // Max Bits Per Sample
-#define MICIN_MIN_SAMPLE_RATE               44100    // Min Sample Rate
-#define MICIN_MAX_SAMPLE_RATE               44100   // Max Sample Rate
+#define MICIN_MIN_SAMPLE_RATE               JJOC_MIC_SAMPLE_RATE	// Min Sample Rate
+#define MICIN_MAX_SAMPLE_RATE               JJOC_MIC_SAMPLE_RATE	// Max Sample Rate
 
 //
 // Max # of pin instances.
@@ -37,11 +40,11 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE MicInPinSupportedDeviceFormats[] =
 		{
 			{
 				WAVE_FORMAT_EXTENSIBLE,
-				2,
-				44100,
-				176400,
-				4,
-				16,
+				2,	// nChannel
+				JJOC_MIC_SAMPLE_RATE,
+				JJOC_MIC_SAMPLE_RATE * 4,	// JJOC_MIC_SAMPLE_RATE * nBlockAlign
+				4,	// nBlockAlign = nChannel * bitPerSample / 8
+				16,	// bitPerSample
 				sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
 			},
 			16,

--- a/AudioMirror/SpeakerWaveProperties.h
+++ b/AudioMirror/SpeakerWaveProperties.h
@@ -2,6 +2,8 @@
 
 #include "Globals.h"
 
+#define JJOC_SPK_SAMPLE_RATE						48000
+
 #define SPEAKER_DEVICE_MAX_CHANNELS               2       // Max Channels.
 
 #define SPEAKER_MAX_INPUT_SYSTEM_STREAMS            1
@@ -11,8 +13,8 @@
 #define SPEAKER_HOST_MAX_CHANNELS                   2       // Max Channels.
 #define SPEAKER_HOST_MIN_BITS_PER_SAMPLE            16      // Min Bits Per Sample
 #define SPEAKER_HOST_MAX_BITS_PER_SAMPLE            16      // Max Bits Per Sample
-#define SPEAKER_HOST_MIN_SAMPLE_RATE                44100   // Min Sample Rate
-#define SPEAKER_HOST_MAX_SAMPLE_RATE                44100   // Max Sample Rate
+#define SPEAKER_HOST_MIN_SAMPLE_RATE                JJOC_SPK_SAMPLE_RATE	// Min Sample Rate
+#define SPEAKER_HOST_MAX_SAMPLE_RATE                JJOC_SPK_SAMPLE_RATE	// Max Sample Rate
 
 #define SPEAKER_OFFLOAD_MAX_CHANNELS                2       // Max Channels.
 #define SPEAKER_OFFLOAD_MIN_BITS_PER_SAMPLE         16      // Min Bits Per Sample
@@ -36,11 +38,11 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHostPinSupportedDeviceFormats[] =
 		{
 			{
 				WAVE_FORMAT_EXTENSIBLE,
-				2,
-				44100,
-				176400,
-				4,
-				16,
+				2,	// nChannels
+				JJOC_SPK_SAMPLE_RATE,
+				JJOC_SPK_SAMPLE_RATE * 4,	// JJOC_SPK_SAMPLE_RATE * nBlockAlign
+				4,	// nBlockAlign = nChannel * bitPerSample / 8
+				16,	// bitPerSample
 				sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
 			},
 			16,


### PR DESCRIPTION
**본 PR에서 샘플레이트를 44.1k -> 48k 변환**

아래와 같은 배경
- Windows에서는 build-in resampler 제공 ([AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM flag](https://github.com/naudio/NAudio/issues/819) 사용)
- 방법은 AudioClient 초기화 시에 해당 flag 같이 넣어주면되고 JUCE 코드에서도 이를 확인. 다만, 지금 사용하고 있는 Shared 모드에서만 해당 flag를 넣어주고 있다. (Low Latency 모드에서는 사용 x)
- Window doc에서는 Low Latency 모드에서 사용 여부에 대한 내용은 찾지 못함.
- 일단 드라이버의 SampleRate를 44.1k -> 48k로 변경 후 GSEP 테스트 진행해봄

GSEP 테스트 현황
- RelWithDebug 모드에서 대략 30~40% CPU Usage 보임 -> **최신 GSEP 20% 이하**
- XRun도 간헐적으로 올라감. -> **최신 GSEP에서는 해결됨.**
- Latency는 측정해본바 150 ms (ㄷㄷ 결국 Low Latency 모드를 쓰게 되어야 할지도 모른다. 하지만 WIndow built-in resampler 사용 못할 수도 있으므로 이를 체크해보아야함.) ->  **Low Latency 작업중**
- JJOC에서 2가지 버그 발생
1) 채널 설정이 안맞는 것 같다. 스테레오 출력인데 한쪽만 소리가남. -> **BLE 장치 버그 픽스로 해결**
2) GSEP 돌리고 난 소리가 노이즈 제거가 제대로 안되는 것 같다. -> **GSEP 업데이트 예정**

